### PR TITLE
設定漏れルールを追加・微調整

### DIFF
--- a/index.js
+++ b/index.js
@@ -386,7 +386,7 @@ module.exports = {
     'indent': [2, 2],
     // JSX 属性のクオートスタイル
     // http://eslint.org/docs/rules/jsx-quotes
-    'jsx-quotes': [2, 'prefer-double'],
+    'jsx-quotes': 0,  // kanmu/react 側で有効化
     // オブジェクトリテラルのキーまわり空白スタイル
     // http://eslint.org/docs/rules/key-spacing
     'key-spacing': [2, { 'beforeColon': false, 'afterColon': true }],

--- a/index.js
+++ b/index.js
@@ -390,6 +390,12 @@ module.exports = {
     // オブジェクトリテラルのキーまわり空白スタイル
     // http://eslint.org/docs/rules/key-spacing
     'key-spacing': [2, { 'beforeColon': false, 'afterColon': true }],
+    // 改行コードを指定
+    // http://eslint.org/docs/rules/linebreak-style
+    'linebreak-style': [2, 'unix'],
+    // コメントまわりの改行スタイル
+    // http://eslint.org/docs/rules/lines-around-comment
+    'lines-around-comment': [2, {'beforeBlockComment': true, 'allowBlockStart': true, 'allowObjectStart': true, 'allowArrayStart': true}],
     // callback ネスト数の制限
     // http://eslint.org/docs/rules/max-nested-callbacks
     'max-nested-callbacks': [1, 3],

--- a/react.js
+++ b/react.js
@@ -15,6 +15,13 @@ module.exports = extend(true, {}, base, {
     'no-invalid-this': 0, // ES7 Property Initializers の関数をうまく判定できない
 
     /**
+     * Stylistic Issues
+     */
+    // JSX 属性のクオートスタイル
+    // http://eslint.org/docs/rules/jsx-quotes
+    'jsx-quotes': [2, 'prefer-double'],
+
+    /**
      * React
      */
     // displayName属性有無


### PR DESCRIPTION
- 完全に漏れていた以下の2ルールを追加
  - `linebreak-style`: 改行コードを unix に強制
  - `line-arround-comment`: ブロックコメントの前に改行強制 (ブロック、配列、オブジェクトの先頭は例外)
- jsx 系のルールを react.js 側に移動