### PR TITLE
ESLint@1.9-1.10, eslint-plugin-react@3.9-3.10 対応

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -9,9 +9,9 @@
   "author": "Kanmu, Inc.",
   "license": "MIT",
   "devDependencies": {
-    "eslint": "^1.8.0",
+    "eslint": "^1.10.1",
     "eslint-config-kanmu": "file:..",
-    "eslint-plugin-react": "^3.6.2"
+    "eslint-plugin-react": "^3.10.0"
   },
   "private": true
 }

--- a/index.js
+++ b/index.js
@@ -131,6 +131,9 @@ module.exports = {
     // alert 禁止
     // http://eslint.org/docs/rules/no-alert
     'no-alert': 2,
+    // case/default 文内での変数宣言にブロック構文を強制
+    // http://eslint.org/docs/rules/no-case-declarations
+    'no-case-declarations': 2,
     // caller, callee 禁止
     // http://eslint.org/docs/rules/no-caller
     'no-caller': 2,
@@ -479,7 +482,7 @@ module.exports = {
     'quotes': [2, 'single'],
     // JSDoc 強制
     // http://eslint.org/docs/rules/require-jsdoc
-    'require-jsdoc': 2,
+    'require-jsdoc': [2, {'require': {'FunctionDeclaration': true, 'MethodDefinition': true, 'ClassDeclaration': true}}],
     // セミコロン強制
     // http://eslint.org/docs/rules/semi
     'semi': 2,

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "eslint": "^1.10.0",
-    "eslint-plugin-react": "^3.6.2"
+    "eslint-plugin-react": "^3.10.0"
   },
   "keywords": [
     "eslint",

--- a/react.js
+++ b/react.js
@@ -42,6 +42,9 @@ module.exports = extend(true, {}, base, {
     // 属性のインデントスタイル
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent-props.md
     'react/jsx-indent-props': [2, 2],
+    // key属性付与を強制
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md
+    'react/jsx-key': 2,
     // 1行あたりの最大属性数
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-max-props-per-line.md
     'react/jsx-max-props-per-line': [2, 2],
@@ -51,6 +54,9 @@ module.exports = extend(true, {}, base, {
     // 未定義の React コンポーネントを使用禁止
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-undef.md
     'react/jsx-no-undef': 2,
+    // コンポーネント名にパスカルケースの使用を強制
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md
+    'react/jsx-pascal-case': 2,
     // propTypes の定義をアルファベット順に制限
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-prop-types.md
     'react/jsx-sort-prop-types': 2,
@@ -71,7 +77,7 @@ module.exports = extend(true, {}, base, {
     'react/no-did-mount-set-state': [2, 'allow-in-func'],
     // componentDidUpdate 内での setState 禁止
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-update-set-state.md
-    'react/no-did-update-set-state': 2,
+    'react/no-did-update-set-state': [2, 'allow-in-func'],
     // state の直接更新禁止
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-direct-mutation-state.md
     'react/no-direct-mutation-state': 2,


### PR DESCRIPTION
詳しくは Diff とリンク先 URL で

## ESLint

- 新ルール: no-case-declarations: case/default 内での変数宣言時にブロック構文を強制
- 新オプション: require-jsdoc: class, method への jsdoc も強制

## eslint-plugin-react

- 新ルール: jsx-key: key属性強制
- 新ルール: jsx-pascal-case: コンポーネント名をパスカルケースに強制
- 新オプション: react/no-did-update-set-state: componentDidUpdate内でのsteStateを非同期関数で許可