### PR TITLE
eslint-plugin-sorting依存系解消

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ ESLint configurations for Kanmu.
 ## Installation
 
 ```
-npm install --save-dev eslint eslint-config-kanmu
+npm install --save-dev eslint eslint-config-kanmu eslint-plugin-sorting
 ```
 
 ## Usage

--- a/example/package.json
+++ b/example/package.json
@@ -11,7 +11,8 @@
   "devDependencies": {
     "eslint": "^1.8.0",
     "eslint-config-kanmu": "file:..",
-    "eslint-plugin-react": "^3.6.2"
+    "eslint-plugin-react": "^3.6.2",
+    "eslint-plugin-sorting": "0.0.1"
   },
   "private": true
 }

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
     "test": "bash test.sh"
   },
   "dependencies": {
-    "eslint-plugin-sorting": "0.0.1",
     "extend": "^3.0.0"
   },
   "devDependencies": {
     "eslint": "^1.10.0",
-    "eslint-plugin-react": "^3.6.2"
+    "eslint-plugin-react": "^3.6.2",
+    "eslint-plugin-sorting": "0.0.1"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
- dependenciesに指定しても利用しているプロジェクトのpluingsで読み込めないので意味なかった
- なので README に追記した…