### PR TITLE
Add negative numbers to ignore in no-magic-numbers

### DIFF
--- a/es5.js
+++ b/es5.js
@@ -21,7 +21,7 @@ module.exports = extend(true, {}, base, {
     'vars-on-top': 2,
     // マジックナンバー禁止
     // http://eslint.org/docs/rules/no-magic-numbers
-    'no-magic-numbers': [2, {enforceConst: false}],  // const 縛りを解除
+    'no-magic-numbers': [2, {enforceConst: false, ignore: [-2, -1, 0, 1, 2]}],  // const 縛りを解除
 
     /**
      * Variables

--- a/index.js
+++ b/index.js
@@ -188,7 +188,7 @@ module.exports = {
     'no-loop-func': 2,
     // マジックナンバー禁止
     // http://eslint.org/docs/rules/no-magic-numbers
-    'no-magic-numbers': [2, {enforceConst: true}],  // const に縛りたい
+    'no-magic-numbers': [2, {enforceConst: true, ignore: [-2, -1, 0, 1, 2]}],  // const に縛りたい
     // 複数空白禁止
     // http://eslint.org/docs/rules/no-multi-spaces
     'no-multi-spaces': 2,


### PR DESCRIPTION
- 既存の[0, 1, 2] に加えて、そのマイナス値くらいは許してあげたくなった…

ref. [Rule no-magic-numbers - ESLint - Pluggable JavaScript linter](http://eslint.org/docs/rules/no-magic-numbers.html)