### PR TITLE
ESLint2系対応 / extends方式変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,29 +18,84 @@ npm install --save-dev eslint eslint-config-kanmu eslint-plugin-sorting
 
 Add `.eslintrc` (YAML).
 
-### ES6
+### Summary
+
+- **Base**
+  - `kanmu`: ES2015
+  - `kanmu/es5`: ES5
+- **Optional**
+  - `kanmu/browser`: Browser env
+  - `kanmu/flow`: for Flow
+  - `kanmu/flow-jsdoc`: for JSDoc and Flow
+  - `kanmu/node`: for Node.js env
+  - `kanmu/react`: for React
+  - `kanmu/react-native`: for React Native
+  - `kanmu/mocha`: for Testing mocha
+
+### Examples
+
+#### ES6 (Node.js)
 
 ```yaml
-extends: kanmu
+extends:
+  - kanmu
+  - kanmu/node
 ```
 
-### ES5
+#### ES5 (Browser)
 
 ```yaml
-extends: kanmu/es5
+extends:
+  - kanmu/es5
+  - kanmu/browser
 ```
 
-### React
+#### React
 
 ```yaml
-extends: kanmu/react
+extends:
+  - kanmu
+  - kanmu/browser
+  - kanmu/react
 ```
 
-#### Additional Requirements
+##### Additional Requirements
 
 ```
 npm install --save-dev eslint-plugin-react
 ```
+
+#### React Native
+
+```yaml
+extends:
+  - kanmu
+  - kanmu/react-native
+```
+
+##### Additional Requirements
+
+```
+npm install --save-dev eslint-plugin-react eslint-plugin-react-native
+```
+
+
+#### React Native with Flow
+
+```yaml
+extends:
+  - kanmu
+  - kanmu/react-native
+  - kanmu/flow
+  - kanmu/flow-jsdoc
+```
+
+##### Additional Requirements
+
+```
+npm install --save-dev eslint-plugin-flow-vars eslint-plugin-jsdoc eslint-plugin-react eslint-plugin-react-native
+```
+
 
 [npm-url]: https://www.npmjs.com/package/eslint-config-kanmu
 [npm-image]: https://img.shields.io/npm/v/eslint-config-kanmu.svg

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,5 @@
+module.exports = {
+  'env': {
+    'browser': true
+  }
+};

--- a/es5.js
+++ b/es5.js
@@ -2,7 +2,9 @@ var extend = require('extend');
 var base = require('./');
 
 module.exports = extend(true, {}, base, {
-  'ecmaFeatures': {'modules': false},
+  'parserOptions': {
+    'sourceType': 'script'
+  },
   'env': {'es6': false},
 
   'rules': {
@@ -56,12 +58,12 @@ module.exports = extend(true, {}, base, {
     // generator の * の空白スタイル
     // http://eslint.org/docs/rules/generator-star-spacing
     'generator-star-spacing': 0,
-    // 条件式への arrow function 混入禁止
-    // http://eslint.org/docs/rules/no-arrow-condition
-    'no-arrow-condition': 0,
     // class への再代入禁止
     // http://eslint.org/docs/rules/no-class-assign
     'no-class-assign': 0,
+    // 条件式とまぎらわしいarrow functionを警告
+    // http://eslint.org/docs/rules/no-confusing-arrow
+    'no-confusing-arrow': 0,
     // const への再代入禁止
     // http://eslint.org/docs/rules/no-const-assign
     'no-const-assign': 0,
@@ -71,6 +73,9 @@ module.exports = extend(true, {}, base, {
     // コンストラクタ内 super の前の this 禁止
     // http://eslint.org/docs/rules/no-this-before-super
     'no-this-before-super': 0,
+    // 不要なコンストラクタ関数の禁止
+    // http://eslint.org/docs/rules/no-useless-constructor
+    'no-useless-constructor': 0,
     // var 禁止
     // http://eslint.org/docs/rules/no-var
     'no-var': 0,
@@ -86,6 +91,9 @@ module.exports = extend(true, {}, base, {
     // Reflect メソッドの利用提案
     // http://eslint.org/docs/rules/prefer-reflect
     'prefer-reflect': 0,
+    // rest-paramsの利用提案 (arguments禁止)
+    // http://eslint.org/docs/rules/prefer-rest-params
+    'prefer-rest-params': 0,
     // Spread オペレータの利用提案
     // http://eslint.org/docs/rules/prefer-spread
     'prefer-spread': 0,
@@ -94,6 +102,12 @@ module.exports = extend(true, {}, base, {
     'prefer-template': 0,
     // yield の必須化
     // http://eslint.org/docs/rules/require-yield
-    'require-yield': 0
+    'require-yield': 0,
+    // テンプレートリテラルの`${..}`の空白スタイル
+    // http://eslint.org/docs/rules/template-curly-spacing
+    'template-curly-spacing': 0,
+    // yieldの*まわりの空白スタイル
+    // http://eslint.org/docs/rules/yield-star-spacing
+    'yield-star-spacing': 0
   }
 });

--- a/example/package.json
+++ b/example/package.json
@@ -9,9 +9,12 @@
   "author": "Kanmu, Inc.",
   "license": "MIT",
   "devDependencies": {
-    "eslint": "^1.8.0",
+    "eslint": "^2.4.0",
+    "eslint-plugin-flow-vars": "^0.2.1",
+    "eslint-plugin-jsdoc": "^2.3.1",
     "eslint-config-kanmu": "file:..",
-    "eslint-plugin-react": "^3.6.2",
+    "eslint-plugin-react": "^4.2.3",
+    "eslint-plugin-react-native": "^1.0.0",
     "eslint-plugin-sorting": "0.0.1"
   },
   "private": true

--- a/flow-jsdoc.js
+++ b/flow-jsdoc.js
@@ -1,0 +1,56 @@
+module.exports = {
+  'plugins': ['jsdoc'],
+  'rules': {
+    /**
+     * Possible Errors
+     */
+    // 不正な JSDoc を禁止
+    // http://eslint.org/docs/rules/valid-jsdoc
+    'valid-jsdoc': 0,  // plugin-jsdocを利用するので無効化
+
+    /**
+     * jsdoc
+     */
+    // https://github.com/gajus/eslint-plugin-jsdoc#check-param-names
+    // @paramと引数名の一致を確認
+    'jsdoc/check-param-names': 2,
+    // https://github.com/gajus/eslint-plugin-jsdoc#check-tag-names
+    // タグの名前(@param, @returns, etc...)が正しいか確認
+    'jsdoc/check-tag-names': 2,
+    // https://github.com/gajus/eslint-plugin-jsdoc#check-types
+    // 型名(number, string, etc...)が正しいか確認
+    'jsdoc/check-types': 0,
+    // https://github.com/gajus/eslint-plugin-jsdoc#newline-after-description
+    // descriptionのあとに改行を強制
+    'jsdoc/newline-after-description': 2,
+    // https://github.com/gajus/eslint-plugin-jsdoc#require-description-complete-sentence
+    // descriptionを文章形式にすることを強制
+    'jsdoc/require-description-complete-sentence': 0,
+    // https://github.com/gajus/eslint-plugin-jsdoc#require-hyphen-before-param-description
+    // @paramの説明の前にハイフンを強制
+    'jsdoc/require-hyphen-before-param-description': 2,
+    // https://github.com/gajus/eslint-plugin-jsdoc#require-param
+    // @paramを強制
+    'jsdoc/require-param': 2,
+    // https://github.com/gajus/eslint-plugin-jsdoc#require-param-description
+    // @paramにdescriptionを強制
+    'jsdoc/require-param-description': 2,
+    // https://github.com/gajus/eslint-plugin-jsdoc#require-param-type
+    // @paramにtypeを強制
+    'jsdoc/require-param-type': 0,
+    // https://github.com/gajus/eslint-plugin-jsdoc#require-returns-description
+    // @returnsにdescriptionを強制
+    'jsdoc/require-returns-description': 0,
+    // https://github.com/gajus/eslint-plugin-jsdoc#require-returns-type
+    // @returnsにtypeを強制
+    'jsdoc/require-returns-type': 0
+  },
+  'settings': {
+    'jsdoc': {
+      // タグ名のエイリアスを定義
+      'tagNamePreference': {
+        'returns': 'return'
+      }
+    }
+  }
+};

--- a/flow.js
+++ b/flow.js
@@ -1,0 +1,22 @@
+module.exports = {
+  'globals': {
+    '$Diff': true,
+    '$Enum': true,
+    '$Shape': true,
+    '$Subtype': true,
+    '$Supertype': true,
+    'Class': true,
+    'ReactClass': true,
+    'ReactComponent': true,
+    'ReactElement': true
+  },
+  'plugins': ['flow-vars'],
+  'rules': {
+    // 未定義のflowtype利用を警告
+    // https://github.com/zertosh/eslint-plugin-flow-vars
+    'flow-vars/define-flow-type': 2,
+    // 未利用のflowtypeを警告
+    // https://github.com/zertosh/eslint-plugin-flow-vars
+    'flow-vars/use-flow-type': 2
+  }
+};

--- a/index.js
+++ b/index.js
@@ -3,9 +3,7 @@ module.exports = {
     'sourceType': 'module'
   },
   'env': {
-    'browser': true,
-    'es6': true,
-    'node': true
+    'es6': true
   },
   'plugins': ['sorting'],
 

--- a/index.js
+++ b/index.js
@@ -132,6 +132,9 @@ module.exports = {
     // alert 禁止
     // http://eslint.org/docs/rules/no-alert
     'no-alert': 2,
+    // case/default 文内での変数宣言にブロック構文を強制
+    // http://eslint.org/docs/rules/no-case-declarations
+    'no-case-declarations': 2,
     // caller, callee 禁止
     // http://eslint.org/docs/rules/no-caller
     'no-caller': 2,
@@ -480,7 +483,7 @@ module.exports = {
     'quotes': [2, 'single'],
     // JSDoc 強制
     // http://eslint.org/docs/rules/require-jsdoc
-    'require-jsdoc': 2,
+    'require-jsdoc': [2, {'require': {'FunctionDeclaration': true, 'MethodDefinition': true, 'ClassDeclaration': true}}],
     // セミコロン強制
     // http://eslint.org/docs/rules/semi
     'semi': 2,

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 module.exports = {
-  'ecmaFeatures': {'modules': true},
+  'parserOptions': {
+    'sourceType': 'module'
+  },
   'env': {
     'browser': true,
     'es6': true,
@@ -91,7 +93,18 @@ module.exports = {
     'use-isnan': 2,
     // 不正な JSDoc を禁止
     // http://eslint.org/docs/rules/valid-jsdoc
-    'valid-jsdoc': [2, {'requireReturn': false, 'requireReturnDescription': false}],
+    'valid-jsdoc': [2, {
+      'preferType': {
+        'Boolean': 'boolean',
+        'function': 'Function',
+        'Number': 'number',
+        'object': 'Object',
+        'String': 'string',
+        'Symbol': 'symbol'
+      },
+      'requireReturn': false,
+      'requireReturnDescription': false
+    }],
     // 不正な type 文字列を禁止
     // http://eslint.org/docs/rules/valid-typeof
     'valid-typeof': 2,
@@ -102,6 +115,9 @@ module.exports = {
     // getter / setter の組み合わせを強制
     // http://eslint.org/docs/rules/accessor-pairs
     'accessor-pairs': 0,
+    // Array系メソッドのコールバック関数で適切にreturnを使用することを強制
+    // http://eslint.org/docs/rules/array-callback-return
+    'array-callback-return': 2,
     // C-style なブロック scope var を強制
     // http://eslint.org/docs/rules/block-scoped-var
     'block-scoped-var': 0,
@@ -144,9 +160,9 @@ module.exports = {
     // else 内 return 禁止
     // http://eslint.org/docs/rules/no-else-return
     'no-else-return': 2,
-    // for, switch 以外での label 禁止
-    // http://eslint.org/docs/rules/no-empty-label
-    'no-empty-label': 2,
+    // コメントのない空関数禁止
+    // http://eslint.org/docs/rules/no-empty-function
+    'no-empty-function': 2,
     // 変数が空になるような destructuring pattern を禁止
     // http://eslint.org/docs/rules/no-empty-pattern
     'no-empty-pattern': 2,
@@ -162,6 +178,9 @@ module.exports = {
     // 不要な bind 禁止
     // http://eslint.org/docs/rules/no-extra-bind
     'no-extra-bind': 2,
+    // 不要なラベルの禁止
+    // http://eslint.org/docs/rules/no-extra-label
+    'no-extra-label': 2,
     // case 文の意図しない fallthrough を禁止
     // http://eslint.org/docs/rules/no-fallthrough
     'no-fallthrough': 2,
@@ -170,10 +189,13 @@ module.exports = {
     'no-floating-decimal': 2,
     // 省略型キャスト表記禁止
     // http://eslint.org/docs/rules/no-implicit-coercion
-    'no-implicit-coercion': [2, {'boolean': false, 'number': true, 'string': true}],
+    'no-implicit-coercion': [2, {'allow': ['!!'], 'boolean': true, 'number': true, 'string': true}],
     // 暗黙の eval 禁止
     // http://eslint.org/docs/rules/no-implied-eval
     'no-implied-eval': 2,
+    // グルーバルスコープへのvar, named functionの禁止
+    // http://eslint.org/docs/rules/no-implicit-globals
+    'no-implicit-globals': 2,
     // 不正な this 禁止
     // http://eslint.org/docs/rules/no-invalid-this
     'no-invalid-this': 2,
@@ -191,7 +213,11 @@ module.exports = {
     'no-loop-func': 2,
     // マジックナンバー禁止
     // http://eslint.org/docs/rules/no-magic-numbers
-    'no-magic-numbers': [2, {enforceConst: true, ignore: [-2, -1, 0, 1, 2]}],  // const に縛りたい
+    'no-magic-numbers': [2, {
+      'enforceConst': true,  // const に縛りたい
+      'ignore': [-2, -1, 0, 1, 2],
+      'ignoreArrayIndexes': true  // 配列の添字は許可
+    }],
     // 複数空白禁止
     // http://eslint.org/docs/rules/no-multi-spaces
     'no-multi-spaces': 2,
@@ -234,6 +260,9 @@ module.exports = {
     // URL 用途の javascript: 禁止
     // http://eslint.org/docs/rules/no-script-url
     'no-script-url': 2,
+    // 自己代入(同名変数への再代入)を禁止
+    // http://eslint.org/docs/rules/no-self-assign
+    'no-self-assign': 2,
     // 同変数比較禁止 (x === x)
     // http://eslint.org/docs/rules/no-self-compare
     'no-self-compare': 2,
@@ -243,9 +272,15 @@ module.exports = {
     // リテラル例外禁止
     // http://eslint.org/docs/rules/no-throw-literal
     'no-throw-literal': 2,
+    // whileやforの条件式に変更されない変数の指定禁止
+    // http://eslint.org/docs/rules/no-unmodified-loop-condition
+    'no-unmodified-loop-condition': 2,
     // 未使用の式禁止
     // http://eslint.org/docs/rules/no-unused-expressions
     'no-unused-expressions': 2,
+    // 未使用ラベルの禁止
+    // http://eslint.org/docs/rules/no-unused-labels
+    'no-unused-labels': 2,
     // 不要な .call() / .apply() の禁止
     // http://eslint.org/docs/rules/no-useless-call
     'no-useless-call': 2,
@@ -296,6 +331,9 @@ module.exports = {
     // 既存変数の label 使用禁止
     // http://eslint.org/docs/rules/no-label-var
     'no-label-var': 2,
+    // 指定グローバル変数の使用禁止
+    // http://eslint.org/docs/rules/no-restricted-globals
+    'no-restricted-globals': 0,  // いったん指定するものなし
     // scope 内の同名変数定義禁止
     // http://eslint.org/docs/rules/no-shadow
     'no-shadow': 2,
@@ -342,7 +380,10 @@ module.exports = {
     // process.exit 禁止
     // http://eslint.org/docs/rules/no-process-exit
     'no-process-exit': 2,
-    // 制限モジュールの使用禁止
+    // 制限モジュールの使用禁止 (module構文)
+    // http://eslint.org/docs/rules/no-restricted-imports
+    'no-restricted-imports': 0,
+    // 制限モジュールの使用禁止 (require関数)
     // http://eslint.org/docs/rules/no-restricted-modules
     'no-restricted-modules': 0,
     // 同期メソッド禁止
@@ -385,6 +426,9 @@ module.exports = {
     // 関数定義スタイル
     // http://eslint.org/docs/rules/func-style
     'func-style': [2, 'declaration', {allowArrowFunctions: true}],
+    // 変数名に使用禁止な名前リスト
+    // http://eslint.org/docs/rules/id-blacklist
+    'id-blacklist': 0,
     // identifier (変数, 引数, プロパティ) の長さを制限
     // http://eslint.org/docs/rules/id-length
     'id-length': 0,
@@ -400,6 +444,9 @@ module.exports = {
     // オブジェクトリテラルのキーまわり空白スタイル
     // http://eslint.org/docs/rules/key-spacing
     'key-spacing': [2, { 'beforeColon': false, 'afterColon': true }],
+    // キーワードまわりの空白スタイル
+    // http://eslint.org/docs/rules/keyword-spacing
+    'keyword-spacing': [2, {'before': true, 'after': true}],
     // 改行コードを指定
     // http://eslint.org/docs/rules/linebreak-style
     'linebreak-style': [2, 'unix'],
@@ -418,6 +465,12 @@ module.exports = {
     // var, let, const 後の空行
     // http://eslint.org/docs/rules/newline-after-var
     'newline-after-var': 0,
+    // returnの前に空行を必須化
+    // http://eslint.org/docs/rules/newline-before-return
+    'newline-before-return': 0,
+    // 1行あたりのchain呼出回数を制限
+    // http://eslint.org/docs/rules/newline-per-chained-call
+    'newline-per-chained-call': [0, {'ignoreChainWithDepth': 3}], // moment等まとまったほうが嬉しいパターンもあるので無効 / 1行に3つ以上のchainを警告
     // Array コンストラクタでの配列要素作成禁止
     // http://eslint.org/docs/rules/no-array-constructor
     'no-array-constructor': 2,
@@ -456,16 +509,22 @@ module.exports = {
     'no-trailing-spaces': 2,
     // 識別子としてのアンダースコアの使用を禁止
     // http://eslint.org/docs/rules/no-underscore-dangle
-    'no-underscore-dangle': 0,
+    'no-underscore-dangle': [2, {'allowAfterThis': true}],  // thisのみ許可
     // 無駄な三項演算子の禁止
     // http://eslint.org/docs/rules/no-unneeded-ternary
     'no-unneeded-ternary': 2,
+    // オブジェクトプロパティアクセスのドット前の空白を禁止
+    // http://eslint.org/docs/rules/no-whitespace-before-property
+    'no-whitespace-before-property': 2,
     // オブジェクトの中括弧内の空白
     // http://eslint.org/docs/rules/object-curly-spacing
     'object-curly-spacing': [2, 'never'],
-    // 1行変数定義スタイル
+    // 変数定義初期化スタイル
     // http://eslint.org/docs/rules/one-var
-    'one-var': [2, {'uninitialized': 'always', 'initialized': 'never'}],
+    'one-var': [2, {'uninitialized': 'always', 'initialized': 'never'}],  // 値なしで初期化する場合はvarを1つにまとめ、値ありで初期化する場合はvarを変数分
+    // 1行変数定義スタイル
+    // http://eslint.org/docs/rules/one-var-declaration-per-line
+    'one-var-declaration-per-line': 0,  // 1行で複数変数を定義することを許可する
     // 変数代入のスタイル
     // http://eslint.org/docs/rules/operator-assignment
     'operator-assignment': 0,
@@ -490,30 +549,24 @@ module.exports = {
     // セミコロンまわりの空白スタイル
     // http://eslint.org/docs/rules/semi-spacing
     'semi-spacing': [2, {'before': false, 'after': true}],
+    // importをアルファベット順に制限
+    // http://eslint.org/docs/rules/sort-imports
+    'sort-imports': 0,  // 期待するソートじゃない
     // 変数定義をアルファベット順に制限
     // http://eslint.org/docs/rules/sort-vars
     'sort-vars': 2,
-    // 特定キーワードの後の空白
-    // http://eslint.org/docs/rules/space-after-keywords
-    'space-after-keywords': [2, 'always'],
     // ブロックの前の空白
     // http://eslint.org/docs/rules/space-before-blocks
     'space-before-blocks': [2, 'always'],
     // 関数の括弧前の空白
     // http://eslint.org/docs/rules/space-before-function-paren
     'space-before-function-paren': [2, 'never'],
-    // 特定キーワードの前の空白
-    // http://eslint.org/docs/rules/space-before-keywords
-    'space-before-keywords': [2, 'always'],
     // 括弧内の空白
     // http://eslint.org/docs/rules/space-in-parens
     'space-in-parens': [2, 'never'],
     // 演算子まわりの空白スタイル
     // http://eslint.org/docs/rules/space-infix-ops
     'space-infix-ops': 2,
-    // return, throw, case まわりの空白強制
-    // http://eslint.org/docs/rules/space-return-throw-case
-    'space-return-throw-case': 2,
     // 演算子まわりの空白
     // http://eslint.org/docs/rules/space-unary-ops
     'space-unary-ops': [2, {'words': true, 'nonwords': false}],
@@ -542,12 +595,12 @@ module.exports = {
     // generator の * の空白スタイル
     // http://eslint.org/docs/rules/generator-star-spacing
     'generator-star-spacing': 2,
-    // 条件式への arrow function 混入禁止
-    // http://eslint.org/docs/rules/no-arrow-condition
-    'no-arrow-condition': 2,
     // class への再代入禁止
     // http://eslint.org/docs/rules/no-class-assign
     'no-class-assign': 2,
+    // 条件式とまぎらわしいarrow functionを警告
+    // http://eslint.org/docs/rules/no-confusing-arrow
+    'no-confusing-arrow': 2,
     // const への再代入禁止
     // http://eslint.org/docs/rules/no-const-assign
     'no-const-assign': 2,
@@ -557,6 +610,9 @@ module.exports = {
     // コンストラクタ内 super の前の this 禁止
     // http://eslint.org/docs/rules/no-this-before-super
     'no-this-before-super': 2,
+    // 不要なコンストラクタ関数の禁止
+    // http://eslint.org/docs/rules/no-useless-constructor
+    'no-useless-constructor': 2,
     // var 禁止
     // http://eslint.org/docs/rules/no-var
     'no-var': 2,
@@ -572,6 +628,9 @@ module.exports = {
     // Reflect メソッドの利用提案
     // http://eslint.org/docs/rules/prefer-reflect
     'prefer-reflect': 0,
+    // rest-paramsの利用提案 (arguments禁止)
+    // http://eslint.org/docs/rules/prefer-rest-params
+    'prefer-rest-params': 2,
     // Spread オペレータの利用提案
     // http://eslint.org/docs/rules/prefer-spread
     'prefer-spread': 2,
@@ -581,6 +640,12 @@ module.exports = {
     // yield の必須化
     // http://eslint.org/docs/rules/require-yield
     'require-yield': 2,
+    // テンプレートリテラルの`${..}`の空白スタイル
+    // http://eslint.org/docs/rules/template-curly-spacing
+    'template-curly-spacing': [2, 'never'],
+    // yieldの*まわりの空白スタイル
+    // http://eslint.org/docs/rules/yield-star-spacing
+    'yield-star-spacing': [2, 'after'],
 
     /**
      * Legacy
@@ -590,7 +655,7 @@ module.exports = {
     'max-depth': [1, 3],
     // 1行の長さ
     // http://eslint.org/docs/rules/max-len
-    'max-len': [1, 100, 2],
+    'max-len': [1, {'code': 100, 'tabWidth': 2, 'ignoreUrls': true}],  // URLは無視
     // 引数の数
     // http://eslint.org/docs/rules/max-params
     'max-params': [1, 3],

--- a/index.js
+++ b/index.js
@@ -672,6 +672,6 @@ module.exports = {
      */
     // オブジェクトプロパティ定義をアルファベット順に制限
     // https://github.com/jacobrask/eslint-plugin-sorting
-    'sorting/sort-object-props': 2
+    'sorting/sort-object-props': [2, {'caseSensitive': false, 'ignoreMethods': false}]
   }
 };

--- a/mocha.js
+++ b/mocha.js
@@ -1,0 +1,34 @@
+module.exports = {
+  'env': {
+    'mocha': true
+  },
+  'rules': {
+    /**
+     * Best Practices
+     */
+    // マジックナンバー禁止
+    // http://eslint.org/docs/rules/no-magic-numbers
+    'no-magic-numbers': 0,  // assert対象はしょうがない
+
+    /**
+     * Node.js
+     */
+    // top-level 以外での require を禁止
+    // http://eslint.org/docs/rules/global-require
+    'global-require': 0,  // beforeEach等でrequireしたい
+
+    /**
+     * Stylistic Issues
+     */
+    // callback ネスト数の制限
+    // http://eslint.org/docs/rules/max-nested-callbacks
+    'max-nested-callbacks': [1, 12],  // describe, context ネスト上等なので緩和
+
+    /**
+     * Legacy
+     */
+    // 関数内の文の数
+    // http://eslint.org/docs/rules/max-statements
+    'max-statements': 0  // 必然的に多くなるので除外
+  }
+}

--- a/node.js
+++ b/node.js
@@ -1,0 +1,5 @@
+module.exports = {
+  'env': {
+    'node': true
+  }
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,13 @@
   "main": "index.js",
   "files": [
     "index.js",
+    "browser.js",
+    "flow.js",
+    "flow-jsdoc.js",
+    "mocha.js",
+    "node.js",
     "react.js",
+    "react-native.js",
     "es5.js"
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,11 @@
     "extend": "^3.0.0"
   },
   "devDependencies": {
-    "eslint": "^1.10.0",
-    "eslint-plugin-react": "^4.0.0",
+    "eslint": "^2.4.0",
+    "eslint-plugin-flow-vars": "^0.2.1",
+    "eslint-plugin-jsdoc": "^2.3.1",
+    "eslint-plugin-react": "^4.2.3",
+    "eslint-plugin-react-native": "^1.0.0",
     "eslint-plugin-sorting": "0.0.1"
   },
   "keywords": [

--- a/react-native.js
+++ b/react-native.js
@@ -1,0 +1,21 @@
+var extend = require('extend');
+var react = require('./react');
+
+module.exports = extend(true, {}, react, {
+  'plugins': ['react', 'react-native'],
+  'env': {
+    'browser': true,
+    'node': true
+  },
+  'globals': {
+    '__DEV__': true
+  },
+  'rules': {
+    // 未利用のStyleを警告
+    // https://github.com/intellicode/eslint-plugin-react-native/blob/master/docs/rules/no-unused-styles.md
+    'react-native/no-unused-styles': 2,
+    // Android/iOS用のコンポーネントのファイル分離を推奨 (x.ios.js, x.android.js)
+    // https://github.com/Intellicode/eslint-plugin-react-native/blob/master/docs/rules/split-platform-components.md
+    'react-native/split-platform-components': 0  // 片方のみの場合は不要
+  }
+});

--- a/react.js
+++ b/react.js
@@ -2,7 +2,11 @@ var extend = require('extend');
 var base = require('./');
 
 module.exports = extend(true, {}, base, {
-  'ecmaFeatures': {'jsx': true},
+  'parserOptions': {
+    'ecmaFeatures': {
+      'jsx': true
+    }
+  },
   // npm install eslint-plugin-react
   'plugins': ['react', 'sorting'],
 
@@ -26,7 +30,7 @@ module.exports = extend(true, {}, base, {
      */
     // displayName属性有無
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/display-name.md
-    'react/display-name': [2, {'acceptTranspilerName': true}],
+    'react/display-name': [2, {'ignoreTranspilerName': false}],
     // 曖昧な PropTypes 禁止
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md
     'react/forbid-prop-types': 0,  // 一旦無視
@@ -39,6 +43,15 @@ module.exports = extend(true, {}, base, {
     // 属性式内のスペーススタイル
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md
     'react/jsx-curly-spacing': [2, 'never', {'allowMultiline': true}],
+    // 属性のイコール周辺の空白スタイル
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-equals-spacing.md
+    'react/jsx-equals-spacing': [2, 'never'],
+    // コンポーネントのイベントハンドラ名prefix強制 (ex. <Comp onChange={this.handleChange} />)
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md
+    'react/jsx-handler-names': 0,
+    // JSXタグのインデント
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent.md
+    'react/jsx-indent': [2, 2],  // スペース2
     // 属性のインデントスタイル
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent-props.md
     'react/jsx-indent-props': [2, 2],
@@ -47,7 +60,10 @@ module.exports = extend(true, {}, base, {
     'react/jsx-key': 2,
     // 1行あたりの最大属性数
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-max-props-per-line.md
-    'react/jsx-max-props-per-line': [2, 2],
+    'react/jsx-max-props-per-line': [2, {'maximum': 2}],
+    // propsでの.bind() or arrow function禁止
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md
+    'react/jsx-no-bind': 0,  // flowの都合上bindつかってる
     // props の重複禁止
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md
     'react/jsx-no-duplicate-props': 2,
@@ -57,12 +73,9 @@ module.exports = extend(true, {}, base, {
     // コンポーネント名にパスカルケースの使用を強制
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md
     'react/jsx-pascal-case': 2,
-    // propTypes の定義をアルファベット順に制限
-    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-prop-types.md
-    'react/jsx-sort-prop-types': 2,
     // props の使用をアルファベット順に制限
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-props.md
-    'react/jsx-sort-props': 2,
+    'react/jsx-sort-props': [2, {'callbacksLast': true, 'shorthandFirst': true}],  // 値なしは最初、callback(onXXX)系は最後に
     // React 的に不適切な箇所での no-unused-vars 発動禁止
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-react.md
     'react/jsx-uses-react': 2,
@@ -72,6 +85,9 @@ module.exports = extend(true, {}, base, {
     // dangerouslySetInnerHTML の禁止
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-danger.md
     'react/no-danger': 0,  // 使うときは覚悟を持って使う
+    // deprecatedな記法を警告
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-deprecated.md
+    'react/no-deprecated': 0,  // 必要なさそう
     // componentDidMount 内での setState 禁止
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-mount-set-state.md
     'react/no-did-mount-set-state': [2, 'allow-in-func'],
@@ -81,12 +97,18 @@ module.exports = extend(true, {}, base, {
     // state の直接更新禁止
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-direct-mutation-state.md
     'react/no-direct-mutation-state': 2,
+    // isMounted()を禁止
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md
+    'react/no-is-mounted': 2,
     // 1 ファイル内複数コンポーネント定義を禁止
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md
     'react/no-multi-comp': 2,
     // setState 禁止
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-set-state.md
     'react/no-set-state': 0,  // ストイックすぎる
+    // 文字列refの禁止
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md
+    'react/no-string-refs': 2,
     // 不適切な DOM 属性使用の禁止
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md
     'react/no-unknown-property': 2,
@@ -102,15 +124,22 @@ module.exports = extend(true, {}, base, {
     // ES6 class を使うよう強制
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md
     'react/prefer-es6-class': 2,
+    // stateless Componentを使うよう強制
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-stateless-function.md
+    'react/prefer-stateless-function': 2,
     // コンポーネントの不要な閉じタグを禁止
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md
     'react/self-closing-comp': 2,
+    // 閉じタグ前に空白を強制
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-space-before-closing.md
+    'react/jsx-space-before-closing': [2, 'always'],
     // React コンポーネントメソッド定義順
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md
     'react/sort-comp': [
       2,
       {
         'order': [
+          'static-methods',
           'lifecycle',
           'everything-else',
           '/^on.+$/',
@@ -146,6 +175,9 @@ module.exports = extend(true, {}, base, {
         }
       }
     ],
+    // propTypes の定義をアルファベット順に制限
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-prop-types.md
+    'react/sort-prop-types': 2,
     // 括弧のない複数行の JSX を禁止
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/wrap-multilines.md
     'react/wrap-multilines': 2

--- a/react.js
+++ b/react.js
@@ -1,7 +1,7 @@
 var extend = require('extend');
 var base = require('./');
 
-module.exports = extend(true, {}, base, {
+module.exports = {
   'parserOptions': {
     'ecmaFeatures': {
       'jsx': true
@@ -182,4 +182,4 @@ module.exports = extend(true, {}, base, {
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/wrap-multilines.md
     'react/wrap-multilines': 2
   }
-});
+};

--- a/react.js
+++ b/react.js
@@ -127,6 +127,7 @@ module.exports = extend(true, {}, base, {
             'mixins',
             'statics',
             'defaultProps',
+            'props',
             'getStores',
             'calculateState',
             'state',

--- a/react.js
+++ b/react.js
@@ -42,6 +42,9 @@ module.exports = extend(true, {}, base, {
     // 属性のインデントスタイル
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent-props.md
     'react/jsx-indent-props': [2, 2],
+    // key属性付与を強制
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md
+    'react/jsx-key': 2,
     // 1行あたりの最大属性数
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-max-props-per-line.md
     'react/jsx-max-props-per-line': [2, 2],
@@ -51,6 +54,9 @@ module.exports = extend(true, {}, base, {
     // 未定義の React コンポーネントを使用禁止
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-undef.md
     'react/jsx-no-undef': 2,
+    // コンポーネント名にパスカルケースの使用を強制
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md
+    'react/jsx-pascal-case': 2,
     // propTypes の定義をアルファベット順に制限
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-prop-types.md
     'react/jsx-sort-prop-types': 2,
@@ -71,7 +77,7 @@ module.exports = extend(true, {}, base, {
     'react/no-did-mount-set-state': [2, 'allow-in-func'],
     // componentDidUpdate 内での setState 禁止
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-update-set-state.md
-    'react/no-did-update-set-state': 2,
+    'react/no-did-update-set-state': [2, 'allow-in-func'],
     // state の直接更新禁止
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-direct-mutation-state.md
     'react/no-direct-mutation-state': 2,


### PR DESCRIPTION
- 新ルール、新オプション、削除ルール等々に対応 (diff参照)
  - ESLint 1.9 - 2.4
  - eslint-plugin-react 3.9 - 4.2
- extendsに複数指定可能になったので利用方法を変更 (README参照)
  - kanmu(ES2015) or kanmu/es5 (ES5) からベースを選択、オプションを追加するようにした
  - 既存設定は次のオプションに分割: `kanmu/node`, `kanmu/browser`, `kanmu/react`
- よく使う設定をオプションとして追加した
  - `kanmu/flow`, `kanmu/jsdoc-flow`, `kanmu/mocha`, `kanmu/react-native`

詳細な説明は以下を参照
- [ESLint v2.0.0 の変更点まとめ - Qiita](http://qiita.com/mysticatea/items/8bcecd821cca9e849078)
- [ESLint v2.3.0 released - ESLint - Pluggable JavaScript linter](http://eslint.org/blog/2016/03/eslint-v2.3.0-released)
- [ESLint v2.4.0 released - ESLint - Pluggable JavaScript linter](http://eslint.org/blog/2016/03/eslint-v2.4.0-released)