### PR TITLE
ESLint 2.7対応

### DIFF
--- a/es5.js
+++ b/es5.js
@@ -70,6 +70,9 @@ module.exports = extend(true, {}, base, {
     // クラスメンバ名の重複禁止
     // http://eslint.org/docs/rules/no-dupe-class-members
     'no-dupe-class-members': 0,
+    // importの重複禁止
+    // http://eslint.org/docs/rules/no-duplicate-imports
+    'no-duplicate-imports': 0,
     // コンストラクタ内 super の前の this 禁止
     // http://eslint.org/docs/rules/no-this-before-super
     'no-this-before-super': 0,

--- a/example/package.json
+++ b/example/package.json
@@ -9,8 +9,8 @@
   "author": "Kanmu, Inc.",
   "license": "MIT",
   "devDependencies": {
-    "eslint": "^2.4.0",
-    "eslint-plugin-flow-vars": "^0.2.1",
+    "eslint": "^2.7.0",
+    "eslint-plugin-flow-vars": "^0.3.0",
     "eslint-plugin-jsdoc": "^2.3.1",
     "eslint-config-kanmu": "file:..",
     "eslint-plugin-react": "^4.2.3",

--- a/index.js
+++ b/index.js
@@ -285,6 +285,9 @@ module.exports = {
     // 不要な文字列連結の禁止
     // http://eslint.org/docs/rules/no-useless-concat
     'no-useless-concat': 2,
+    // 不要なエスケープの禁止
+    // http://eslint.org/docs/rules/no-useless-escape
+    'no-useless-escape': 2,
     // void 禁止
     // http://eslint.org/docs/rules/no-void
     'no-void': 2,
@@ -454,6 +457,9 @@ module.exports = {
     // callback ネスト数の制限
     // http://eslint.org/docs/rules/max-nested-callbacks
     'max-nested-callbacks': [1, 3],
+    // 1行の文の数を制限
+    // http://eslint.org/docs/rules/max-statements-per-line
+    'max-statements-per-line': 0,  // ここまで厳密にしなくてもよさそう
     // コンストラクタの new 必須化
     // http://eslint.org/docs/rules/new-cap
     'new-cap': 2,
@@ -602,6 +608,9 @@ module.exports = {
     // const への再代入禁止
     // http://eslint.org/docs/rules/no-const-assign
     'no-const-assign': 2,
+    // importの重複禁止
+    // http://eslint.org/docs/rules/no-duplicate-imports
+    'no-duplicate-imports': 2,
     // クラスメンバ名の重複禁止
     // http://eslint.org/docs/rules/no-dupe-class-members
     'no-dupe-class-members': 2,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "extend": "^3.0.0"
   },
   "devDependencies": {
-    "eslint": "^2.4.0",
+    "eslint": "^2.7.0",
     "eslint-plugin-flow-vars": "^0.3.0",
     "eslint-plugin-jsdoc": "^2.3.1",
     "eslint-plugin-react": "^4.2.3",


### PR DESCRIPTION
- ESLint 2.5で追加された3つのルールを追加
  - `no-duplicate-imports`: importの重複禁止
  - `no-useless-escape`: 不要なエスケープの禁止
  - `max-statements-per-line`: 1行の文の数を制限

ref. [ESLint v2.5.0 - Qiita](http://qiita.com/mysticatea/items/7018ca26abfa7701debc)