### PR TITLE
ESLint 3.10対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ extends:
 ##### Additional Requirements
 
 ```
-npm install --save-dev eslint-plugin-flow-vars eslint-plugin-jsdoc eslint-plugin-react eslint-plugin-react-native
+npm install --save-dev eslint-plugin-flowtype eslint-plugin-jsdoc eslint-plugin-react eslint-plugin-react-native
 ```
 
 

--- a/flow.js
+++ b/flow.js
@@ -40,6 +40,9 @@ module.exports = {
     // 逃げの型を禁止
     // https://github.com/gajus/eslint-plugin-flowtype
     'flowtype/no-weak-types': 0,  // 逃げたいときはある
+    // オブジェクト属性の区切り記号
+    // https://github.com/gajus/eslint-plugin-flowtype
+    'flowtype/object-type-delimiter': [2, 'comma'],
     // 引数の型付けを強制
     // https://github.com/gajus/eslint-plugin-flowtype
     'flowtype/require-parameter-type': 0,  // flow側にまかせたいときがある

--- a/index.js
+++ b/index.js
@@ -269,6 +269,9 @@ module.exports = {
     // return 文での変数代入禁止
     // http://eslint.org/docs/rules/no-return-assign
     'no-return-assign': 2,
+    // 不要なawait文の禁止
+    // http://eslint.org/docs/rules/no-return-await
+    'no-return-await': 2,
     // URL 用途の javascript: 禁止
     // http://eslint.org/docs/rules/no-script-url
     'no-script-url': 2,
@@ -302,6 +305,9 @@ module.exports = {
     // 不要なエスケープの禁止
     // http://eslint.org/docs/rules/no-useless-escape
     'no-useless-escape': 2,
+    // 不要なreturn文の禁止
+    // http://eslint.org/docs/rules/no-useless-return
+    'no-useless-return': 2,
     // void 禁止
     // http://eslint.org/docs/rules/no-void
     'no-void': 2,
@@ -319,7 +325,7 @@ module.exports = {
     'vars-on-top': 0,
     // 即時関数の括弧のスタイル
     // http://eslint.org/docs/rules/wrap-iife
-    'wrap-iife': [2, 'inside'],
+    'wrap-iife': [2, 'inside', {'functionPrototypeMethods': true}],
     // 評価式内のリテラルと変数の記述順スタイル
     // http://eslint.org/docs/rules/yoda
     'yoda': [2, 'never'],
@@ -438,6 +444,9 @@ module.exports = {
     // 関数呼び出しの括弧前の空白スタイル
     // http://eslint.org/docs/rules/func-call-spacing
     'func-call-spacing': 2,
+    // 関数名と代入先の変数・プロパティ名が合致
+    // http://eslint.org/docs/rules/func-name-matching
+    'func-name-matching': 0,
     // 関数名を持たせるための function 式を強制
     // http://eslint.org/docs/rules/func-names
     'func-names': 2,
@@ -605,7 +614,7 @@ module.exports = {
     'space-before-blocks': [2, 'always'],
     // 関数の括弧前の空白
     // http://eslint.org/docs/rules/space-before-function-paren
-    'space-before-function-paren': [2, 'never'],
+    'space-before-function-paren': [2, {'anonymous': 'never', 'named': 'never', 'asyncArrow': 'always'}],
     // 括弧内の空白
     // http://eslint.org/docs/rules/space-in-parens
     'space-in-parens': [2, 'never'],

--- a/react.js
+++ b/react.js
@@ -94,6 +94,9 @@ module.exports = {
     // props の使用をアルファベット順に制限
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-props.md
     'react/jsx-sort-props': [2, {'callbacksLast': true, 'shorthandFirst': true}],  // 値なしは最初、callback(onXXX)系は最後に
+    // jsxタグの空白ルール
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-tag-spacing.md
+    'react/jsx-tag-spacing': 2,
     // React 的に不適切な箇所での no-unused-vars 発動禁止
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-react.md
     'react/jsx-uses-react': 2,


### PR DESCRIPTION
各アップデートによる更新を反映した。
詳しい変更点はコメントと以下を参照すること。

- eslint
  - [ESLint v3.8.0 - Qiita](http://qiita.com/mysticatea/items/6f037c15057c57982453)
  - [ESLint v3.9.0 - Qiita](http://qiita.com/mysticatea/items/abc7885b373b5b37ce97)
  - [ESLint v3.10.0 - Qiita](http://qiita.com/mysticatea/items/b987cd002aee911044f0)
- eslint-plugin-react
  - [eslint-plugin-react/jsx-tag-spacing](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-tag-spacing.md)
- eslint-plugin-flowtype
  - [eslint-plugin-flowtype/object-type-delimiter](https://github.com/gajus/eslint-plugin-flowtype#eslint-plugin-flowtype-rules-object-type-delimiter)
