### PR TITLE
chore: Remove flowtype/sort-keys option

### DIFF
--- a/flow.js
+++ b/flow.js
@@ -83,7 +83,7 @@ module.exports = {
     'flowtype/semi': [2, 'always'],
     // プロパティの並び順
     // https://github.com/gajus/eslint-plugin-flowtype
-    'flowtype/sort-keys': [2, 'asc', {'caseSensitive': true, 'natural': true}],
+    'flowtype/sort-keys': [2, 'asc'],
     // コロン後の空白スタイル
     // https://github.com/gajus/eslint-plugin-flowtype
     'flowtype/space-after-type-colon': [2, 'always'],


### PR DESCRIPTION
Removed additional parameter from `flowtype/sort-keys` for eslint-plugin-flowtype removed it on v5.0.
https://github.com/gajus/eslint-plugin-flowtype/releases/tag/v5.0.0