### PR TITLE
Update eslint-plugin-jsdoc to v43

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -14,7 +14,7 @@
     "eslint-config-kanmu": "file:..",
     "eslint-plugin-flowtype": "^2.39.1",
     "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-jsdoc": "^41.0.0",
+    "eslint-plugin-jsdoc": "^43.0.7",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-react": "^7.5.1",
     "eslint-plugin-react-native": "^4.0.0"

--- a/index.js
+++ b/index.js
@@ -841,9 +841,6 @@ module.exports = {
     // 型名(number, string, etc...)が正しいか確認
     // https://github.com/gajus/eslint-plugin-jsdoc#check-types
     'jsdoc/check-types': 2,
-    // descriptionのあとに改行を強制
-    // https://github.com/gajus/eslint-plugin-jsdoc#newline-after-description
-    'jsdoc/newline-after-description': 2,
     // descriptionを文章形式にすることを強制
     // https://github.com/gajus/eslint-plugin-jsdoc#require-description-complete-sentence
     'jsdoc/require-description-complete-sentence': 0,
@@ -873,7 +870,14 @@ module.exports = {
     'jsdoc/require-returns-description': 2,
     // @returnsにtypeを強制
     // https://github.com/gajus/eslint-plugin-jsdoc#require-returns-type
-    'jsdoc/require-returns-type': 2
+    'jsdoc/require-returns-type': 2,
+    // タグ間の空行スタイル
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/main/.README/rules/tag-lines.md
+    'jsdoc/tag-lines': [
+      2,
+      'any',  // タグ間の空行スタイルを強制しない
+      {'startLines': 1}  // descriptionのあとに改行を強制
+    ]
   },
   'settings': {
     'jsdoc': {

--- a/package.json
+++ b/package.json
@@ -24,13 +24,14 @@
     "eslint": "^8.23.0",
     "eslint-plugin-flowtype": "^2.39.1",
     "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-jsdoc": "^41.0.0",
+    "eslint-plugin-jsdoc": "^43.0.7",
     "eslint-plugin-react": "^7.5.1",
     "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-react-native": "^4.0.0"
   },
   "peerDependencies": {
     "eslint": "^8.23.0",
+    "eslint-plugin-jsdoc": ">=42.0.0",
     "eslint-plugin-node": ">=11.1.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
- 依存を現状最新版に更新した
  - v42 で `newline-after-description` が削除され, `tag-lines` に移行するため、 `eslint-plugin-jsdoc` の `peerDependencies` は v42 以上に設定する
    - https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v42.0.0
      - https://github.com/gajus/eslint-plugin-jsdoc/blob/v41.1.2/.README/rules/newline-after-description.md
      - https://github.com/gajus/eslint-plugin-jsdoc/blob/v43.0.7/.README/rules/tag-lines.md
    - `eslint-plugin-jsdoc` は `index.js` に含まれていて全体に適用されるため、 `peerDependenciesMeta` に `optional` のような条件は設定しない
- `newline-after-description` は、ほぼ既存ルールを踏襲する形で `tag-lines` に置き換えた
  - タグ間の空行は現行ルールでは設定されていないため `any` に
  - description のあとは空行を挿入するようにしていたため、v42.0.0 の Release Notes に従い `startLines: 1` に
  - ただし最後のタグのあとの余分な空行を検知するようになり、それをエラーとするため、**この変更をもって BREAKING CHANGE になる**